### PR TITLE
Update lama_inpaint.py

### DIFF
--- a/lama_inpaint.py
+++ b/lama_inpaint.py
@@ -24,7 +24,6 @@ from saicinpainting.evaluation.refinement import refine_predict
 from utils import load_img_to_array, save_array_to_img
 
 
-@torch.no_grad()
 def inpaint_img_with_lama(
         img: np.ndarray,
         mask: np.ndarray,


### PR DESCRIPTION
Thank you very much for your work.

Feature refinement does backward propagation when inferencing large images. Therefore, to prevent error, @torch.no_grad() should be removed.